### PR TITLE
refactor: drop useless action checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,19 +31,18 @@ runs:
     - name: Install poetry
       shell: bash
       run: pipx install poetry
-    - name: Change to action directory
-      shell: bash
-      run: cd ${{ github.action_path }}
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
         cache: poetry
-    - run: poetry install --only main --no-interaction
+    - name: Install Python dependencies
       working-directory: ${{ github.action_path }}
       shell: bash
-    - run: poetry run gha_handler
+      run: poetry install --only main --no-interaction
+    - name: Run action script
       working-directory: ${{ github.action_path }}
       shell: bash
+      run: poetry run gha_handler
       env:
         NOTION_API_TIMEOUT: ${{ inputs.NOTION_API_TIMEOUT }}
         NOTION_API_KEY: ${{ inputs.NOTION_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,13 @@ runs:
   steps:
     # - uses: actions/checkout@v3
     #   with:
-    #     repository: " Mergifyio/gha-changelog-syncer"
+    #     repository: "Mergifyio/gha-changelog-syncer"
+    - name: Install poetry
+      shell: bash
+      run: ls
+    - name: Install poetry
+      shell: bash
+      run: ls ../
     - name: Install poetry
       shell: bash
       run: pipx install poetry

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-        cache: poetry
+        # cache: poetry
     - name: Install Python dependencies
       working-directory: ${{ github.action_path }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ runs:
     - name: Install poetry
       shell: bash
       run: pipx install poetry
+    - name: Change to action directory
+      shell: bash
+      run: cd ${{ github.action_path }}
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,7 @@ runs:
       shell: bash
       run: pipx install poetry
     - uses: actions/setup-python@v4
+      working-directory: ${{ github.action_path }}
       with:
         python-version: "3.10"
         cache: poetry

--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-      with:
-        repository: " Mergifyio/gha-changelog-syncer"
+    # - uses: actions/checkout@v3
+    #   with:
+    #     repository: " Mergifyio/gha-changelog-syncer"
     - name: Install poetry
       shell: bash
       run: pipx install poetry

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,6 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-        # cache: poetry
     - name: Install Python dependencies
       working-directory: ${{ github.action_path }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,7 @@ runs:
     #     repository: "Mergifyio/gha-changelog-syncer"
     - name: Install poetry
       shell: bash
-      run: ls
-    - name: Install poetry
-      shell: bash
-      run: ls ../
+      run: echo ${{github.action_path}}
     - name: Install poetry
       shell: bash
       run: pipx install poetry

--- a/action.yml
+++ b/action.yml
@@ -28,13 +28,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install poetry
-      shell: bash
-      run: pipx install poetry
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Install poetry
+      shell: bash
+      run: pipx install poetry
     - name: Install Python dependencies
       working-directory: ${{ github.action_path }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -28,12 +28,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # - uses: actions/checkout@v3
-    #   with:
-    #     repository: "Mergifyio/gha-changelog-syncer"
-    - name: Install poetry
-      shell: bash
-      run: echo ${{github.action_path}}
     - name: Install poetry
       shell: bash
       run: pipx install poetry
@@ -42,8 +36,10 @@ runs:
         python-version: "3.10"
         cache: poetry
     - run: poetry install --only main --no-interaction
+      working-directory: ${{ github.action_path }}
       shell: bash
     - run: poetry run gha_handler
+      working-directory: ${{ github.action_path }}
       shell: bash
       env:
         NOTION_API_TIMEOUT: ${{ inputs.NOTION_API_TIMEOUT }}

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ runs:
     - name: Install poetry
       shell: bash
       run: pipx install poetry
-    - uses: actions/setup-python@v4
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - name: Install Python dependencies

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,6 @@ runs:
       shell: bash
       run: pipx install poetry
     - uses: actions/setup-python@v4
-      working-directory: ${{ github.action_path }}
       with:
         python-version: "3.10"
         cache: poetry


### PR DESCRIPTION
Previously, the action checked out the source code. It happens that the action source code is already checked out. We can leverage the `github.action_path` context to use it as a working directory.

This allows dropping the explicit reference to the action repository name, which used to be problematic.